### PR TITLE
While preserving user data, users are guaranteed to update to new entries added in new version.

### DIFF
--- a/addon/globalPlugins/searchWith.py
+++ b/addon/globalPlugins/searchWith.py
@@ -325,7 +325,7 @@ configspec={
 	"menuItems": "list(default=list())",
 	"lang": "integer(default=0)",
 	"useAsDefaultQuery": "integer(default=0)",
-	"preserveDataFolder": "boolean(default=False)",
+	"preserveDataFolder": "boolean(default=True)",
 }
 config.conf.spec["searchWith"]= configspec
 if not config.conf["searchWith"]["menuItems"]:
@@ -414,8 +414,8 @@ class SearchWithPanel(gui.SettingsPanel):
 		# For advanced users group
 		# Translators: Label of group for advanced users.
 		staticCheckSizer= sHelper.addItem(wx.StaticBoxSizer(wx.VERTICAL, self, _("For advanced users")))
-		# Translators: Label of checkbox preserve data folder.
-		self.advancedCheckbox= wx.CheckBox(staticCheckSizer.GetStaticBox(), label=_("Preserve data folder upon installing a new version"))
+		# Translators: Label of checkbox preserve data.
+		self.advancedCheckbox= wx.CheckBox(staticCheckSizer.GetStaticBox(), label=_("Preserve data upon installing a new version"))
 		staticCheckSizer.Add(self.advancedCheckbox)
 		self.advancedCheckbox.SetValue(config.conf["searchWith"]["preserveDataFolder"])
 

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -1,17 +1,18 @@
 # installTasks.py
 # Copyright 2021 Ibrahim Hamadeh , released under GPL2.0
-# required to preserve data folder, mainly for advanced users. 
+# required to preserve data mainly for advanced users. 
 
 import os
 import config
-import shutil
+import json
 from logHandler import log
 
+
 def onInstall():
-	# path of data folder in previously installed version.
-	src= os.path.join(os.path.abspath(os.path.dirname(__file__)), '..', 'searchWith', 'data')
-	# path of data folder in the pending install version.
-	dest= os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
+	# path of data in previously installed version.
+	src= os.path.join(os.path.abspath(os.path.dirname(__file__)), '..', 'searchWith', 'data', 'otherEngines.json')
+	# path of data in the pending install version.
+	dest= os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data', 'otherEngines.json')
 
 	try:
 		preserve= config.conf["searchWith"]["preserveDataFolder"]
@@ -21,10 +22,16 @@ def onInstall():
 	else:
 		# when we ininstall the addon, configuration stays.
 		# So we should make sure that a previous version exist.
-		if preserve and os.path.isdir(src):
-			# The user wants to preserve data folder.
+		if preserve and os.path.exists(src):
+			# The user wants to preserve data
 			try:
-				shutil.rmtree(dest, ignore_errors=True)
-				shutil.copytree(src, dest)
-			except :
-				log.info("Error trying to preserve data folder", exc_info= True)
+				with open(src, 'r', encoding='utf-8') as s, open(dest, 'r', encoding='utf-8') as d:
+					src_Data = json.load(s)
+					dest_Data = json.load(d)
+				# Merge dictionaries, but keep user data, while updating newly added entries
+				merge_Data={**dest_Data, **src_Data}
+				# Just save the merged dictionary
+				with open(dest, 'w', encoding='utf-8') as f:
+					json.dump(merge_Data, f, indent=4, sort_keys=False, ensure_ascii=False)
+			except:
+				log.error("Error trying to preserve data", exc_info= True)


### PR DESCRIPTION

While preserving user data, users are guaranteed to update to new entries added in new version.

## My solution to this problem
In Python 3.5+, a new way of merging dictionaries is available:
```merge_Data={**dest_Data, **src_Data}```

* If the user modifies or adds some entries in "otherEngines.json", these entries will not be overwritten when installing a new version.
* If the new version of the add-on adds some new entries, then these entries will be added to 'otherEngines.json'.

## Additional instruction

The main work of this PR is done in `installTasks.py`.

I also modified the comments and UI descriptions related to this PR accordingly, excluding `readme.md`.
