### PR TITLE
Fixed a parameter error in BoxSizerHelper that caused the settings panel to fail to load.

### DIFF
--- a/addon/globalPlugins/searchWith/__init__.py
+++ b/addon/globalPlugins/searchWith/__init__.py
@@ -439,10 +439,10 @@ class SearchWithPanel(gui.settingsDialogs.SettingsPanel):
 		self.availableLanguages = languageHandler.getAvailableLanguages(presentational=True)
 		googleChoices = [x[1] for x in self.availableLanguages]
 		deepLChoices = [x[1] for x in deepLLanguages]
-		sizer1= gui.guiHelper.BoxSizerHelper(staticTranslationEnginesSizer.GetStaticBox(), orientation= wx.VERTICAL)
+		sizer1= gui.guiHelper.BoxSizerHelper(self, orientation= wx.VERTICAL)
 		# Translators: Label of combo box for google translate.
 		self.googleTranslateComboBox = sizer1.addLabeledControl(_("Target language for google translate:"), wx.Choice, choices= googleChoices)
-		sizer2 = gui.guiHelper.BoxSizerHelper(staticTranslationEnginesSizer.GetStaticBox(), orientation= wx.VERTICAL)
+		sizer2 = gui.guiHelper.BoxSizerHelper(self, orientation= wx.VERTICAL)
 		# Translators: Label of combo box for deepL translate.
 		self.deepLTranslateComboBox= sizer2.addLabeledControl(_("Target language for deepL translate:"), wx.Choice, choices= deepLChoices)
 		self.googleTranslateComboBox.SetSelection([indx for indx, val in enumerate(self.availableLanguages) if val[0]== config.conf["searchWith"]["googleTranslateLang"]][0])


### PR DESCRIPTION
## Description
Navigating to serch-with panel within the NVDA settings category list throws the following error:
```log
DEBUG - gui.contextHelp.bindHelpEvent (13:16:25.266) - MainThread (12652):
Did context help binding for SearchWithPanel
ERROR - unhandled exception (13:16:25.401) - MainThread (12652):
Traceback (most recent call last):
  File "gui\settingsDialogs.pyc", line 4607, in onCategoryChange
  File "gui\settingsDialogs.pyc", line 694, in onCategoryChange
  File "gui\settingsDialogs.pyc", line 676, in _doCategoryChange
  File "gui\settingsDialogs.pyc", line 604, in _getCategoryPanel
  File "gui\settingsDialogs.pyc", line 363, in __init__
  File "gui\settingsDialogs.pyc", line 373, in _buildGui
  File "C:\Users\cary\AppData\Roaming\nvda\addons\searchWith\globalPlugins\searchWith\__init__.py", line 448, in makeSettings
    self.deepLTranslateComboBox= sizer2.addLabeledControl(_("Target language for deepL translate:"), wx.Choice, choices= deepLChoices)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "gui\guiHelper.pyc", line 390, in addLabeledControl
  File "gui\guiHelper.pyc", line 249, in __init__
wx._core.wxAssertionError: C++ assertion ""parent"" failed at ..\..\src\common\ctrlcmn.cpp(79) in wxControlBase::CreateControl(): all controls must have parents
```

We should give `gui.guiHelper.BoxSizerHelper` a parent.

## Fix method
Just change the first parameter to `self` when calling gui.guiHelper.BoxSizerHelper.
