### PR TITLE
Fix a bug in failing to load setting panel in development NVDA releases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ addon/doc/en/
 *.nvda-addon
 .sconsign.dblite
 *.exe
+*.bat

--- a/addon/globalPlugins/searchWith/__init__.py
+++ b/addon/globalPlugins/searchWith/__init__.py
@@ -439,14 +439,14 @@ class SearchWithPanel(gui.settingsDialogs.SettingsPanel):
 		self.availableLanguages = languageHandler.getAvailableLanguages(presentational=True)
 		googleChoices = [x[1] for x in self.availableLanguages]
 		deepLChoices = [x[1] for x in deepLLanguages]
-		sizer1= gui.guiHelper.BoxSizerHelper(staticTranslationEnginesSizer.GetStaticBox(), orientation= wx.VERTICAL)
+		googleTranslateSizer = gui.guiHelper.BoxSizerHelper(staticTranslationEnginesSizer.GetStaticBox(), orientation= wx.VERTICAL)
 		# Translators: Label of combo box for google translate.
-		staticText1= sizer1.addItem(wx.StaticText(staticTranslationEnginesSizer.GetStaticBox(), label= _("Target language for google translate:")))
-		self.googleTranslateComboBox = sizer1.addItem(wx.Choice(staticTranslationEnginesSizer.GetStaticBox(), choices= googleChoices))
-		sizer2 = gui.guiHelper.BoxSizerHelper(staticTranslationEnginesSizer.GetStaticBox(), orientation= wx.VERTICAL)
+		googleTranslateSizer.addItem(wx.StaticText(staticTranslationEnginesSizer.GetStaticBox(), label= _("Target language for google translate:")))
+		self.googleTranslateComboBox = googleTranslateSizer.addItem(wx.Choice(staticTranslationEnginesSizer.GetStaticBox(), choices= googleChoices))
+		deepLTranslateSizer = gui.guiHelper.BoxSizerHelper(staticTranslationEnginesSizer.GetStaticBox(), orientation= wx.VERTICAL)
 		# Translators: Label of combo box for deepL translate.
-		staticText2 = sizer2.addItem(wx.StaticText(staticTranslationEnginesSizer.GetStaticBox(), label= _("Target language for deepL translate:")))
-		self.deepLTranslateComboBox= sizer2.addItem(wx.Choice(staticTranslationEnginesSizer.GetStaticBox(), choices= deepLChoices))
+		deepLTranslateSizer.addItem(wx.StaticText(staticTranslationEnginesSizer.GetStaticBox(), label= _("Target language for deepL translate:")))
+		self.deepLTranslateComboBox= deepLTranslateSizer.addItem(wx.Choice(staticTranslationEnginesSizer.GetStaticBox(), choices= deepLChoices))
 		self.googleTranslateComboBox.SetSelection([indx for indx, val in enumerate(self.availableLanguages) if val[0]== config.conf["searchWith"]["googleTranslateLang"]][0])
 		self.deepLTranslateComboBox.SetSelection([indx for indx, val in enumerate(deepLLanguages) if val[0]== config.conf["searchWith"]["deepLTranslateLang"]][0])
 

--- a/addon/globalPlugins/searchWith/__init__.py
+++ b/addon/globalPlugins/searchWith/__init__.py
@@ -439,12 +439,14 @@ class SearchWithPanel(gui.settingsDialogs.SettingsPanel):
 		self.availableLanguages = languageHandler.getAvailableLanguages(presentational=True)
 		googleChoices = [x[1] for x in self.availableLanguages]
 		deepLChoices = [x[1] for x in deepLLanguages]
-		sizer1= gui.guiHelper.BoxSizerHelper(self, orientation= wx.VERTICAL)
+		sizer1= gui.guiHelper.BoxSizerHelper(staticTranslationEnginesSizer.GetStaticBox(), orientation= wx.VERTICAL)
 		# Translators: Label of combo box for google translate.
-		self.googleTranslateComboBox = sizer1.addLabeledControl(_("Target language for google translate:"), wx.Choice, choices= googleChoices)
-		sizer2 = gui.guiHelper.BoxSizerHelper(self, orientation= wx.VERTICAL)
+		staticText1= sizer1.addItem(wx.StaticText(staticTranslationEnginesSizer.GetStaticBox(), label= _("Target language for google translate:")))
+		self.googleTranslateComboBox = sizer1.addItem(wx.Choice(staticTranslationEnginesSizer.GetStaticBox(), choices= googleChoices))
+		sizer2 = gui.guiHelper.BoxSizerHelper(staticTranslationEnginesSizer.GetStaticBox(), orientation= wx.VERTICAL)
 		# Translators: Label of combo box for deepL translate.
-		self.deepLTranslateComboBox= sizer2.addLabeledControl(_("Target language for deepL translate:"), wx.Choice, choices= deepLChoices)
+		staticText2 = sizer2.addItem(wx.StaticText(staticTranslationEnginesSizer.GetStaticBox(), label= _("Target language for deepL translate:")))
+		self.deepLTranslateComboBox= sizer2.addItem(wx.Choice(staticTranslationEnginesSizer.GetStaticBox(), choices= deepLChoices))
 		self.googleTranslateComboBox.SetSelection([indx for indx, val in enumerate(self.availableLanguages) if val[0]== config.conf["searchWith"]["googleTranslateLang"]][0])
 		self.deepLTranslateComboBox.SetSelection([indx for indx, val in enumerate(deepLLanguages) if val[0]== config.conf["searchWith"]["deepLTranslateLang"]][0])
 

--- a/buildVars.py
+++ b/buildVars.py
@@ -32,9 +32,9 @@ select some text and press once, a menu will be displayed with various search en
 And while text is selected, you can press the gesture twice to search with Google directly.
 The Default gesture for the addon is: NVDA+ Windows+ S."""),
 	# version
-	"addon_version": "2.6.0",
+	"addon_version": "2.6.1",
 	# Author(s)
-	"addon_author": "ibrahim hamadeh <ibra.hamadeh@hotmail.com>",
+	"addon_author": "ibrahim hamadeh <ibra.hamadeh@hotmail.com>, Cary Rowen <manchen_0528@outlook.com>",
 	# URL for the add-on documentation support
 	"addon_url": "https://github.com/ibrahim-s/searchWith/blob/master/readme.md",
 	# URL for the add-on repository where the source code can be found

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,8 @@
 # Search With #
 
-*	Author: Ibrahim Hamadeh
-*	Contributors: Cary Rowen
+*	Authors: Ibrahim Hamadeh, Cary Rowen
 *	NVDA compatibility: 2019.3 and beyond
-*	Download [Stable version 2.6.0][1]
+*	Download [Stable version 2.6.1][1]
 
 This addon helps you to search text, via various search engines.  
 Let no text selected, and press the gesture of the addon  
@@ -60,6 +59,11 @@ And if clipboard or last spoken text is chosen, text in search box will be displ
 You can through a check box in setting panel, choose if you want to preserve your data folder upon installing a new version.  
 This means that your data will be sustained, but added to it the newly entries in the new version.  
 And that's it, hope to search for good and find it, happy searching!  
+
+### Changes for 2.6.1 ###
+
+*	Fix a bug, in failing to load searchWith setting panel, in NVDA development releases  
+Now we use .addItem() instead of .addLabledControl() to add controls to translation engine grouping, thanks to Cary Rowen for helps.
 
 ### Changes for 2.6.0 ###
 
@@ -166,4 +170,4 @@ but the new entries in the new version, will be merged and added to your old dat
 
 *	Initial version  
 
-[1]: https://github.com/ibrahim-s/searchWith/releases/download/2.6.0/searchWith-2.6.0.nvda-addon
+[1]: https://github.com/ibrahim-s/searchWith/releases/download/2.6.1/searchWith-2.6.1.nvda-addon


### PR DESCRIPTION
In this PR, we tried to fix the bug in failing to load setting panel in development releases.
the issue was caused by adding controls to translation engines grouping
By using addItem() instead of addLabledCtrl() we was able to restore loading of setting panel, at the same time the grouping of controls under translate engines window was preserved.

